### PR TITLE
Preserve `color()` names and use as labels in `plot()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # prismatic (development version)
 
+* `color()` now maintains the names of the input vector, allowing `plot()` to use the color names rather than the hex values when `label = TRUE`. You can also provide `label` with a custom set of color labels. Unnamed colors are labelled with their hex values (@gadenbuie #27).
+
 # prismatic 1.1.1
 
 * Fixed documentation to be HTML5 friendly.

--- a/R/aaa.R
+++ b/R/aaa.R
@@ -15,3 +15,7 @@ rgb_norm <- function(x) {
 pro_transform <- function(data, value, ratio) {
   value * ratio + data * (1 - ratio)
 }
+
+has_names <- function(x) {
+  !is.null(names(x)) || any(nzchar(names(x)))
+}

--- a/R/color.R
+++ b/R/color.R
@@ -30,9 +30,12 @@
 color <- function(col) {
   if (is.list(col)) stop("`col` must not be a list.")
   if (length(col) < 0) stop("The length of `col` must be positive.")
-  col <- rgb2col(col2rgb(col, alpha = TRUE), alpha = TRUE)
-  attr(col, "class") <- "colors"
-  col
+  colors <- rgb2col(col2rgb(col, alpha = TRUE), alpha = TRUE)
+  if (has_names(col)) {
+    names(colors) <- names(col)
+  }
+  attr(colors, "class") <- "colors"
+  colors
 }
 
 #' @rdname color

--- a/R/color.R
+++ b/R/color.R
@@ -70,9 +70,20 @@ plot.colors <- function(x, labels = FALSE, ...) {
     xleft = seq_along(x) - 0.5, ybottom = 0, xright = seq_along(x) + 0.5,
     ytop = 1, col = x, border = NA
   )
-  if (labels) {
+  if (is.logical(labels)) {
+    color_labels <- if (has_names(x)) names(x) else x
+    show_labels <- isTRUE(labels)
+  } else {
+    stopifnot(
+      "`labels` must be a character" = is.character(labels),
+      "`labels` must be the same length as `x`" = length(x) == length(labels)
+    )
+    color_labels <- labels
+    show_labels <- TRUE
+  }
+  if (show_labels) {
     label_col <- vapply(x, best_contrast, FUN.VALUE = character(1))
-    text(x = seq_along(x), y = 0.5, labels = x, srt = 90, col = label_col)
+    text(x = seq_along(x), y = 0.5, labels = color_labels, srt = 90, col = label_col)
   }
   rect(xleft = 0.5, ybottom = 0, xright = length(x) + 0.5, ytop = 1)
 }

--- a/R/color.R
+++ b/R/color.R
@@ -82,6 +82,8 @@ plot.colors <- function(x, labels = FALSE, ...) {
     show_labels <- TRUE
   }
   if (show_labels) {
+    # Fill missing color labels with the color hex value
+    color_labels[!nzchar(color_labels)] <- x[!nzchar(color_labels)]
     label_col <- vapply(x, best_contrast, FUN.VALUE = character(1))
     text(x = seq_along(x), y = 0.5, labels = color_labels, srt = 90, col = label_col)
   }

--- a/tests/testthat/test-color.R
+++ b/tests/testthat/test-color.R
@@ -49,3 +49,14 @@ test_that("colour() complains when col type is wrong.", {
   expect_error(colour("not a color"))
   expect_error(colour(list(pal = "#000000")))
 })
+
+test_that("color() retains names", {
+  x <- c(blue = "#0000FF", red = "#FF0000")
+  expect_equal(names(color(x)), names(x))
+
+  y <- c(blue = "#0000FF", "#FF0000")
+  expect_equal(names(color(y)), names(y))
+
+  z <- c("#0000FF", "#FF0000")
+  expect_null(names(color(z)))
+})

--- a/tests/testthat/test-color.R
+++ b/tests/testthat/test-color.R
@@ -60,3 +60,8 @@ test_that("color() retains names", {
   z <- c("#0000FF", "#FF0000")
   expect_null(names(color(z)))
 })
+
+test_that("plot.color() errors with bad label input", {
+  expect_error(plot(color(rainbow(10)), labels = 1:3))
+  expect_error(plot(color(rainbow(10)), labels = paste(1:3)))
+})


### PR DESCRIPTION
This PR does two things:

1. `color()` now retains the names of the original vector, if present
2. `plot.colors()` uses the color names when `label = TRUE`, or `label` can be provided a character vector of color names.

Together, these changes make it easier to use `plot()` to show off a named color palette.

Take this completely random color palette as an example.

``` r
clrs <- c(
  blue = "#447098FF", orange = "#ED6331FF", gray = "#404041FF", 
  teal = "#419498FF", green  = "#72984EFF", burgundy = "#994665FF"
)
```

When passed to `color()`, the original color names are retained.

``` r
pkgload::load_all()
#> ℹ Loading prismatic
clrs <- color(clrs)
clrs
#> <colors>
#> #447098FF #ED6331FF #404041FF #419498FF #72984EFF #994665FF
names(clrs)
#> [1] "blue"     "orange"   "gray"     "teal"     "green"    "burgundy"
```

The default plot methods works as previously (`labels = FALSE` by default)

```r
plot(clrs)
```

![](https://i.imgur.com/56TCvHg.png)

But if labels are requested and if the input vector is named, the names are used for the color labels.

``` r
plot(clrs, labels = TRUE)
```

![](https://i.imgur.com/nRAegSG.png)

If the input vector is unnamed, the HEX value of the color is presented (previous behavior).

``` r
plot(unname(clrs), labels = TRUE)
```

![](https://i.imgur.com/A2Z71z5.png)

Finally, you can also provide `labels` a character vector equal in length to `x` if you'd like to use a different label for each color.

``` r
plot(clrs, labels = paste("Posit", stringr::str_to_title(names(clrs))))
```

![](https://i.imgur.com/1dek5yB.png)